### PR TITLE
Fix touchpad si orientation à 90° (rotate=1)

### DIFF
--- a/LaBoutik.sh
+++ b/LaBoutik.sh
@@ -92,7 +92,7 @@ fi
 if [ "$rotate" -eq 0 ]; then
     sed -i '/Option "CalibrationMatrix"/c        Option "CalibrationMatrix" "1 0 0 0 1 0 0 0 1"' /etc/X11/xorg.conf.d/40-libinput.conf
 elif [ "$rotate" -eq 1 ]; then
-    sed -i '/Option "CalibrationMatrix"/c        Option "CalibrationMatrix" "0 1 0 0 -1 1 0 0 1"' /etc/X11/xorg.conf.d/40-libinput.conf
+    sed -i '/Option "CalibrationMatrix"/c        Option "CalibrationMatrix" "0 1 0 -1 0 1 0 0 1"' /etc/X11/xorg.conf.d/40-libinput.conf
 elif [ "$rotate" -eq 2 ]; then
     sed -i '/Option "CalibrationMatrix"/c        Option "CalibrationMatrix" "-1 0 1 0 -1 1 0 0 1"' /etc/X11/xorg.conf.d/40-libinput.conf
 elif [ "$rotate" -eq 3 ]; then


### PR DESCRIPTION
Sans correctif, le curseur parcourait une diagonale (X=Y proportionnellement aux dimensions de l'écran)
L'inversion de valeur corrige le problème.
Source utilisée : [settings_for_raspberry_pi.html#rotate-touch-angle](https://docs.sunfounder.com/projects/ts-7c/en/latest/settings_for_raspberry_pi.html#rotate-touch-angle)